### PR TITLE
Update the interface to ensure that the interface is consistent with the message passing taxonomy

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,21 +65,21 @@ const client = new KafkaClient({
 });
 ```
 
-## Sending Messages
+## Publishing to a Topic
 
-To send a message a topic, provide the topic name and the message. 
+To publish a message to a topic, provide the topic name and the message. 
 
 ```js
 client.publishToTopic(topic, message);
 ```
 
-## Consuming Messages
+## Subscribing to a Topic
 
 The package uses non-flowing consumer mode with `enable.auto.commit` enabled along with `auto.offset.reset` set to earliest.
 
 The messages are consumed at an interval of 1 second with 10 messages consumed at each interval. 
 
-To consume a message from a topic, provide the topic name and a callback function that would return the message.
+To subscribe to a topic for consuming messages, provide the topic name and a callback function that would return the message.
 
 ```js
 client.subscribeToTopic(topic, onMessage);

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ const client = new KafkaClient({
 To send a message a topic, provide the topic name and the message. 
 
 ```js
-client.sendMessage(topic, message);
+client.publishToTopic(topic, message);
 ```
 
 ## Consuming Messages
@@ -82,7 +82,7 @@ The messages are consumed at an interval of 1 second with 10 messages consumed a
 To consume a message from a topic, provide the topic name and a callback function that would return the message.
 
 ```js
-client.consumeMessage(topic, onMessage);
+client.subscribeToTopic(topic, onMessage);
 ```
 
 ## Disconnection

--- a/__test__/index.test.js
+++ b/__test__/index.test.js
@@ -22,21 +22,21 @@ describe('Kafka client integration tests', () => {
   });
 
   test('should log message when producer is connected', async () => {
-    await kafkaClient.sendMessage(topic, { message: 'Hello Cinemataztic' });
+    await kafkaClient.publishToTopic(topic, { message: 'Hello Cinemataztic' });
     expect(logSpy).toHaveBeenCalledWith(
       'Kafka producer successfully connected',
     );
   });
 
   test('should log message when consumer is connected', async () => {
-    await kafkaClient.consumeMessage(topic, () => {});
+    await kafkaClient.subscribeToTopic(topic, () => {});
     expect(logSpy).toHaveBeenCalledWith(
       'Kafka consumer successfully connected',
     );
   });
 
   test('should log message when consumer receives a message', async () => {
-    await kafkaClient.consumeMessage(topic, (data) => {
+    await kafkaClient.subscribeToTopic(topic, (data) => {
       expect(data).toHaveProperty('value');
       expect(data.value).toHaveProperty('message', 'Hello Cinemataztic');
     });
@@ -45,7 +45,7 @@ describe('Kafka client integration tests', () => {
     await new Promise((resolve) => setTimeout(resolve, 2000));
 
     // Send a message after consumer is ready.
-    await kafkaClient.sendMessage(topic, { message: 'Hello Cinemataztic' });
+    await kafkaClient.publishToTopic(topic, { message: 'Hello Cinemataztic' });
 
     // Wait for the polling (via setInterval) to pick up the message.
     await new Promise((resolve) => setTimeout(resolve, 5000));

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cinemataztic/big-evil-kafka",
-  "version": "1.0.11",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cinemataztic/big-evil-kafka",
-      "version": "1.0.11",
+      "version": "1.1.0",
       "license": "ISC",
       "dependencies": {
         "@kafkajs/confluent-schema-registry": "^3.6.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cinemataztic/big-evil-kafka",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cinemataztic/big-evil-kafka",
-      "version": "1.0.10",
+      "version": "1.0.11",
       "license": "ISC",
       "dependencies": {
         "@kafkajs/confluent-schema-registry": "^3.6.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cinemataztic/big-evil-kafka",
-  "version": "1.0.11",
+  "version": "1.1.0",
   "description": "A wrapper around node-rdkafka",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cinemataztic/big-evil-kafka",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "A wrapper around node-rdkafka",
   "main": "src/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -243,7 +243,7 @@ class KafkaClient {
    * @param {Object} message The message to send to a topic
    * @public
    */
-  async sendMessage(topic, message) {
+  async publishToTopic(topic, message) {
     try {
       await this.#initProducer();
 
@@ -277,7 +277,7 @@ class KafkaClient {
    * @param {onMessage} onMessage A function that processes the decoded message data received by consumer
    * @public
    */
-  async consumeMessage(topic, onMessage) {
+  async subscribeToTopic(topic, onMessage) {
     try {
       await this.#initConsumer();
 


### PR DESCRIPTION
- Rename `consumeMessage` to `subscribeToTopic` in the subscriber.
- Rename `sendMessage` to `publishToTopic` in the producer.