### PR TITLE
Add persistent event listeners to monitor connection health for both producer and consumer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cinemataztic/big-evil-kafka",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cinemataztic/big-evil-kafka",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "ISC",
       "dependencies": {
         "@kafkajs/confluent-schema-registry": "^3.6.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cinemataztic/big-evil-kafka",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cinemataztic/big-evil-kafka",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "ISC",
       "dependencies": {
         "@kafkajs/confluent-schema-registry": "^3.6.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cinemataztic/big-evil-kafka",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "A wrapper around node-rdkafka",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cinemataztic/big-evil-kafka",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "A wrapper around node-rdkafka",
   "main": "src/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -116,10 +116,8 @@ class KafkaClient {
   #registerProducerEventListeners() {
     // If the producer disconnects unexpectedly, set the isProducerConnected flag to false
     this.#producer.on('disconnected', () => {
-      if (this.#isProducerConnected) {
-        console.error('Kafka producer disconnected unexpectedly');
-        this.#isProducerConnected = false;
-      }
+      console.error('Kafka producer disconnected unexpectedly');
+      this.#isProducerConnected = false;
     });
 
     // Capture event errors and set the isProducerConnected flag to false in case of an event error
@@ -132,19 +130,17 @@ class KafkaClient {
   #registerConsumerEventListeners() {
     // If the consumer disconnects unexpectedly, set the isConsumerConnected flag to false
     this.#consumer.on('disconnected', () => {
-      if (this.#isConsumerConnected) {
-        console.error('Kafka consumer disconnected unexpectedly');
-        
-        this.#isConsumerConnected = false;
-        clearInterval(this.#intervalId);
-        this.#intervalId = null;
-      }
+      console.error('Kafka consumer disconnected unexpectedly');
+
+      this.#isConsumerConnected = false;
+      clearInterval(this.#intervalId);
+      this.#intervalId = null;
     });
 
     // Capture event errors and set the isConsumerConnected flag to false in case of an event error
     this.#consumer.on('event.error', (error) => {
       console.error(`Kafka consumer encountered event error: ${error}`);
-      
+
       this.#isConsumerConnected = false;
       clearInterval(this.#intervalId);
       this.#intervalId = null;


### PR DESCRIPTION
- Set up persistent event listeners to monitor connection health for both producer and consumer. This ensures that in case of unexpected disconnection, or event error, the producer/consumer connected state will change and no producer/consumer methods shall be called without reconnecting first.
- Producer/Consumer connection states depend upon unexpected `disconnected` or `event.error` events. If any event is emitted on those channels, the producer/consumer connection state is modified to reflect the current state and ensures that the methods `produce` or `subscribe` are not called internally within publishToTopic and subscribeToTopic.
- Will attempt to retry connection for both producer and consumer in case of unexpected `disconnected` or `event.error` events so that the producer or consumer does not fail silently or require the application to be restarted manually.
- Wraps `disconnectProducer` and `disconnectConsumer` in an exponential backoff retry mechanism to ensure that the methods are called again in case of an error the first time. After multiple retry attempts are reached, the process is killed.