### PR TITLE
Call connectConsumer or connectProducer in case of event errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cinemataztic/big-evil-kafka",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cinemataztic/big-evil-kafka",
-      "version": "1.2.7",
+      "version": "1.2.8",
       "license": "ISC",
       "dependencies": {
         "@kafkajs/confluent-schema-registry": "^3.6.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cinemataztic/big-evil-kafka",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cinemataztic/big-evil-kafka",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "license": "ISC",
       "dependencies": {
         "@kafkajs/confluent-schema-registry": "^3.6.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cinemataztic/big-evil-kafka",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cinemataztic/big-evil-kafka",
-      "version": "1.2.3",
+      "version": "1.2.4",
       "license": "ISC",
       "dependencies": {
         "@kafkajs/confluent-schema-registry": "^3.6.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cinemataztic/big-evil-kafka",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cinemataztic/big-evil-kafka",
-      "version": "1.2.6",
+      "version": "1.2.7",
       "license": "ISC",
       "dependencies": {
         "@kafkajs/confluent-schema-registry": "^3.6.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cinemataztic/big-evil-kafka",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cinemataztic/big-evil-kafka",
-      "version": "1.2.4",
+      "version": "1.2.5",
       "license": "ISC",
       "dependencies": {
         "@kafkajs/confluent-schema-registry": "^3.6.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cinemataztic/big-evil-kafka",
-  "version": "1.2.8",
+  "version": "1.2.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cinemataztic/big-evil-kafka",
-      "version": "1.2.8",
+      "version": "1.2.9",
       "license": "ISC",
       "dependencies": {
         "@kafkajs/confluent-schema-registry": "^3.6.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cinemataztic/big-evil-kafka",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cinemataztic/big-evil-kafka",
-      "version": "1.2.5",
+      "version": "1.2.6",
       "license": "ISC",
       "dependencies": {
         "@kafkajs/confluent-schema-registry": "^3.6.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cinemataztic/big-evil-kafka",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cinemataztic/big-evil-kafka",
-      "version": "1.2.2",
+      "version": "1.2.3",
       "license": "ISC",
       "dependencies": {
         "@kafkajs/confluent-schema-registry": "^3.6.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cinemataztic/big-evil-kafka",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "description": "A wrapper around node-rdkafka",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cinemataztic/big-evil-kafka",
-  "version": "1.2.8",
+  "version": "1.2.9",
   "description": "A wrapper around node-rdkafka",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cinemataztic/big-evil-kafka",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "description": "A wrapper around node-rdkafka",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cinemataztic/big-evil-kafka",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "A wrapper around node-rdkafka",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cinemataztic/big-evil-kafka",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "A wrapper around node-rdkafka",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cinemataztic/big-evil-kafka",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "A wrapper around node-rdkafka",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cinemataztic/big-evil-kafka",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "A wrapper around node-rdkafka",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cinemataztic/big-evil-kafka",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "description": "A wrapper around node-rdkafka",
   "main": "src/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -110,39 +110,75 @@ class KafkaClient {
 
   #registerProducerEventListeners() {
     this.#producer.on('disconnected', async () => {
-      console.error('Kafka producer disconnected unexpectedly. Retrying kafka producer connection');
+      console.error(
+        'Kafka producer disconnected unexpectedly. Retrying kafka producer connection',
+      );
       this.#isProducerConnected = false;
 
-      await this.#initProducer();
+      try {
+        await this.#connectProducer();
+      } catch (error) {
+        console.error(
+          `Kafka producer re-connection failed with error ${error.message}. Max retries reached. Exiting...`,
+        );
+        process.exit(1);
+      }
     });
 
     this.#producer.on('event.error', async (error) => {
-      console.error(`Kafka producer encountered event error: ${error}. Retrying kafka producer connection`);
+      console.error(
+        `Kafka producer encountered event error: ${error}. Retrying kafka producer connection`,
+      );
       this.#isProducerConnected = false;
 
-      await this.#initProducer();
+      try {
+        await this.#connectProducer();
+      } catch (error) {
+        console.error(
+          `Kafka producer re-connection failed with error ${error.message}. Max retries reached. Exiting...`,
+        );
+        process.exit(1);
+      }
     });
   }
 
   #registerConsumerEventListeners() {
     this.#consumer.on('disconnected', async () => {
-      console.error('Kafka consumer disconnected unexpectedly. Retrying kafka consumer connection');
+      console.error(
+        'Kafka consumer disconnected unexpectedly. Retrying kafka consumer connection',
+      );
 
       this.#isConsumerConnected = false;
       clearInterval(this.#intervalId);
       this.#intervalId = null;
 
-      await this.#initConsumer();
+      try {
+        await this.#connectConsumer();
+      } catch (error) {
+        console.error(
+          `Kafka consumer re-connection failed with error ${error.message}. Max retries reached. Exiting...`,
+        );
+        process.exit(1);
+      }
     });
 
     this.#consumer.on('event.error', async (error) => {
-      console.error(`Kafka consumer encountered event error: ${error}. Retrying kafka consumer connection`);
+      console.error(
+        `Kafka consumer encountered event error: ${error}. Retrying kafka consumer connection`,
+      );
 
       this.#isConsumerConnected = false;
       clearInterval(this.#intervalId);
       this.#intervalId = null;
 
-      await this.#initConsumer();
+      try {
+        await this.#connectConsumer();
+      } catch (error) {
+        console.error(
+          `Kafka consumer re-connection failed with error ${error.message}. Max retries reached. Exiting...`,
+        );
+        process.exit(1);
+      }
     });
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -110,75 +110,40 @@ class KafkaClient {
 
   #registerProducerEventListeners() {
     this.#producer.once('disconnected', async () => {
-      console.error(
-        'Kafka producer disconnected unexpectedly. Retrying kafka producer connection',
-      );
+      console.error('Kafka producer disconnected unexpectedly.');
       this.#isProducerConnected = false;
-
-      try {
-        await this.#connectProducer();
-      } catch (error) {
-        console.error(
-          `Kafka producer re-connection failed with error ${error.message}. Max retries reached. Exiting...`,
-        );
-        process.exit(1);
-      }
     });
 
     this.#producer.once('event.error', async (error) => {
-      console.error(
-        `Kafka producer encountered event error: ${error}. Retrying kafka producer connection`,
-      );
+      console.error(`Kafka producer encountered event error: ${error}`);
       this.#isProducerConnected = false;
-
-      try {
-        await this.#connectProducer();
-      } catch (error) {
-        console.error(
-          `Kafka producer re-connection failed with error ${error.message}. Max retries reached. Exiting...`,
-        );
-        process.exit(1);
-      }
     });
   }
 
   #registerConsumerEventListeners() {
     this.#consumer.once('disconnected', async () => {
       console.error(
-        'Kafka consumer disconnected unexpectedly. Retrying kafka consumer connection',
+        'Kafka consumer disconnected unexpectedly. Retrying kafka consumer connection...',
       );
 
       this.#isConsumerConnected = false;
       clearInterval(this.#intervalId);
       this.#intervalId = null;
 
-      try {
-        await this.#connectConsumer();
-      } catch (error) {
-        console.error(
-          `Kafka consumer re-connection failed with error ${error.message}. Max retries reached. Exiting...`,
-        );
-        process.exit(1);
-      }
+      await this.#initConsumer();
     });
 
     this.#consumer.once('event.error', async (error) => {
       console.error(
-        `Kafka consumer encountered event error: ${error}. Retrying kafka consumer connection`,
+        `Kafka consumer encountered event error: ${error}. Retrying kafka consumer connection...`,
       );
 
       this.#isConsumerConnected = false;
       clearInterval(this.#intervalId);
       this.#intervalId = null;
 
-      try {
-        await this.#connectConsumer();
-      } catch (error) {
-        console.error(
-          `Kafka consumer re-connection failed with error ${error.message}. Max retries reached. Exiting...`,
-        );
-        process.exit(1);
-      }
+      this.#consumer.disconnect();
+      await this.#initConsumer();
     });
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -154,8 +154,15 @@ class KafkaClient {
       this.#intervalId = null;
 
       try {
-        await this.disconnectConsumer();
-        await this.#connectConsumer();
+        await new Promise((resolve, reject) => {
+          this.#consumer.disconnect((error) => {
+            if (error) {
+              reject(error);
+            } else {
+              resolve(this.#connectConsumer());
+            }
+          });
+        });
       } catch (error) {
         console.error(
           `Kafka consumer re-connection failed with error ${error.message}. Max retries reached. Exiting...`,

--- a/src/index.js
+++ b/src/index.js
@@ -56,13 +56,25 @@ class KafkaClient {
    * @type {Boolean}
    * @private
    */
-  #isProducerConnected;
+  #isProducerConnected = false;
   /**
    * The consumer connection flag.
    * @type {Boolean}
    * @private
    */
-  #isConsumerConnected;
+  #isConsumerConnected = false;
+  /**
+   * The producer reconnection flag in case of 'disconnection' or 'event.error' events to avoid duplicate reconnection attempts.
+   * @type {Boolean}
+   * @private
+   */
+  #isProducerReconnecting = false;
+  /**
+   * The consumer connection flag in case of 'disconnection' or 'event.error' events to avoid duplicate reconnection attempts.
+   * @type {Boolean}
+   * @private
+   */
+  #isConsumerReconnecting = false;
   /**
    * The interval ID.
    * @type {number | NodeJS.Timeout | null}
@@ -109,27 +121,64 @@ class KafkaClient {
   }
 
   #registerProducerEventListeners() {
-    this.#producer.once('disconnected', async () => {
-      if (this.#isProducerConnected) {
+    this.#producer.on('disconnected', async () => {
+      if (this.#isProducerConnected && !this.#isProducerReconnecting) {
         console.error('Kafka producer disconnected unexpectedly.');
         this.#isProducerConnected = false;
+        this.#isProducerReconnecting = true;
+
+        try {
+          await this.#connectProducer();
+        } catch (error) {
+          console.error(
+            `Kafka producer re-connection failed with error ${error.message}. Max retries reached. Exiting...`,
+          );
+          process.exit(1);
+        }
       }
     });
 
-    this.#producer.once('event.error', async (error) => {
+    this.#producer.on('event.error', async (error) => {
+      if (this.#isProducerReconnecting) {
+        console.log('Kafka producer reconnection is in progress...');
+        return;
+      }
+
       console.error(`Kafka producer encountered event error: ${error}`);
       this.#isProducerConnected = false;
+      this.#isProducerReconnecting = true;
+
+      try {
+        await new Promise((resolve, reject) => {
+          this.#producer.disconnect((err) => {
+            if (err) {
+              reject(err);
+            } else {
+              console.log(
+                `Kafka producer disconnected due to event error: ${error}. Attempting to reconnect kafka producer...`,
+              );
+              resolve(this.#connectProducer());
+            }
+          });
+        });
+      } catch (error) {
+        console.error(
+          `Kafka producer re-connection failed with error ${error.message}. Max retries reached. Exiting...`,
+        );
+        process.exit(1);
+      }
     });
   }
 
   #registerConsumerEventListeners() {
-    this.#consumer.once('disconnected', async () => {
-      if (this.#isConsumerConnected) {
+    this.#consumer.on('disconnected', async () => {
+      if (this.#isConsumerConnected && !this.#isConsumerReconnecting) {
         console.error(
           'Kafka consumer disconnected unexpectedly. Retrying kafka consumer connection...',
         );
 
         this.#isConsumerConnected = false;
+        this.#isConsumerReconnecting = true;
         clearInterval(this.#intervalId);
         this.#intervalId = null;
 
@@ -144,12 +193,15 @@ class KafkaClient {
       }
     });
 
-    this.#consumer.once('event.error', async (error) => {
-      console.error(
-        `Kafka consumer encountered event error: ${error}.`,
-      );
+    this.#consumer.on('event.error', async (error) => {
+      if (this.#isConsumerReconnecting) {
+        console.log('Kafka consumer reconnection is in progress...');
+        return;
+      }
 
+      console.error(`Kafka consumer encountered event error: ${error}.`);
       this.#isConsumerConnected = false;
+      this.#isConsumerReconnecting = true;
       clearInterval(this.#intervalId);
       this.#intervalId = null;
 
@@ -159,7 +211,9 @@ class KafkaClient {
             if (err) {
               reject(err);
             } else {
-              console.log(`Kafka consumer disconnected due to event error: ${error}. Attempting to reconnect kafka consumer...`)
+              console.log(
+                `Kafka consumer disconnected due to event error: ${error}. Attempting to reconnect kafka consumer...`,
+              );
               resolve(this.#connectConsumer());
             }
           });
@@ -189,6 +243,7 @@ class KafkaClient {
           this.#producer.once('ready', () => {
             this.#isProducerConnected = true;
             console.log('Kafka producer successfully connected');
+            this.#isProducerReconnecting = false;
             this.#producer.removeAllListeners('connection.failure');
             resolve();
           });
@@ -223,7 +278,9 @@ class KafkaClient {
           this.#consumer.once('ready', () => {
             this.#isConsumerConnected = true;
             console.log('Kafka consumer successfully connected');
+            this.#isConsumerReconnecting = false;
             this.#consumer.removeAllListeners('connection.failure');
+
             resolve();
           });
 
@@ -366,7 +423,6 @@ class KafkaClient {
             this.#producer.once('disconnected', () => {
               this.#isProducerConnected = false;
               this.#producer.removeAllListeners();
-
               console.log('Successfully disconnected Kafka producer');
             });
 
@@ -402,11 +458,9 @@ class KafkaClient {
           return new Promise((resolve, reject) => {
             this.#consumer.once('disconnected', () => {
               this.#isConsumerConnected = false;
-              this.#consumer.removeAllListeners();
-
               clearInterval(this.#intervalId);
               this.#intervalId = null;
-
+              this.#consumer.removeAllListeners();
               console.log('Successfully disconnected Kafka consumer');
             });
 

--- a/src/index.js
+++ b/src/index.js
@@ -142,7 +142,8 @@ class KafkaClient {
       clearInterval(this.#intervalId);
       this.#intervalId = null;
 
-      this.#consumer.disconnect();
+      // Gracefully disconnect consumer before attempting to connect to consumer again in case of 'event.error'
+      await this.disconnectConsumer();
       await this.#initConsumer();
     });
   }

--- a/src/index.js
+++ b/src/index.js
@@ -146,7 +146,7 @@ class KafkaClient {
 
     this.#consumer.once('event.error', async (error) => {
       console.error(
-        `Kafka consumer encountered event error: ${error}. Retrying kafka consumer connection...`,
+        `Kafka consumer encountered event error: ${error}.`,
       );
 
       this.#isConsumerConnected = false;
@@ -155,10 +155,11 @@ class KafkaClient {
 
       try {
         await new Promise((resolve, reject) => {
-          this.#consumer.disconnect((error) => {
-            if (error) {
-              reject(error);
+          this.#consumer.disconnect((err) => {
+            if (err) {
+              reject(err);
             } else {
+              console.log(`Kafka consumer disconnected due to event error: ${error}. Attempting to reconnect kafka consumer...`)
               resolve(this.#connectConsumer());
             }
           });

--- a/src/index.js
+++ b/src/index.js
@@ -109,7 +109,7 @@ class KafkaClient {
   }
 
   #registerProducerEventListeners() {
-    this.#producer.on('disconnected', async () => {
+    this.#producer.once('disconnected', async () => {
       console.error(
         'Kafka producer disconnected unexpectedly. Retrying kafka producer connection',
       );
@@ -125,7 +125,7 @@ class KafkaClient {
       }
     });
 
-    this.#producer.on('event.error', async (error) => {
+    this.#producer.once('event.error', async (error) => {
       console.error(
         `Kafka producer encountered event error: ${error}. Retrying kafka producer connection`,
       );
@@ -143,7 +143,7 @@ class KafkaClient {
   }
 
   #registerConsumerEventListeners() {
-    this.#consumer.on('disconnected', async () => {
+    this.#consumer.once('disconnected', async () => {
       console.error(
         'Kafka consumer disconnected unexpectedly. Retrying kafka consumer connection',
       );
@@ -162,7 +162,7 @@ class KafkaClient {
       }
     });
 
-    this.#consumer.on('event.error', async (error) => {
+    this.#consumer.once('event.error', async (error) => {
       console.error(
         `Kafka consumer encountered event error: ${error}. Retrying kafka consumer connection`,
       );


### PR DESCRIPTION
- Gracefully disconnect consumer/producer in `event.error` before attempting to connect consumer/producer again.
- Maintain persistent error event listeners i.e. `disconnected` or `event.error` events with guards to ensure multiple attempts to reconnect consumer/producer do not happen. 