### PR TITLE
Enable producer polling.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cinemataztic/big-evil-kafka",
-  "version": "1.2.9",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cinemataztic/big-evil-kafka",
-      "version": "1.2.9",
+      "version": "1.3.0",
       "license": "ISC",
       "dependencies": {
         "@kafkajs/confluent-schema-registry": "^3.6.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cinemataztic/big-evil-kafka",
-  "version": "1.2.9",
+  "version": "1.3.0",
   "description": "A wrapper around node-rdkafka",
   "main": "src/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -80,7 +80,7 @@ class KafkaClient {
    * @type {number | NodeJS.Timeout | null}
    * @private
    */
-  #intervalId;
+  #consumerPollInterval;
 
   /**
    * Initialize Kafka Client
@@ -179,8 +179,8 @@ class KafkaClient {
 
         this.#isConsumerConnected = false;
         this.#isConsumerReconnecting = true;
-        clearInterval(this.#intervalId);
-        this.#intervalId = null;
+        clearInterval(this.#consumerPollInterval);
+        this.#consumerPollInterval = null;
 
         try {
           await this.#connectConsumer();
@@ -202,8 +202,8 @@ class KafkaClient {
       console.error(`Kafka consumer encountered event error: ${error}.`);
       this.#isConsumerConnected = false;
       this.#isConsumerReconnecting = true;
-      clearInterval(this.#intervalId);
-      this.#intervalId = null;
+      clearInterval(this.#consumerPollInterval);
+      this.#consumerPollInterval = null;
 
       try {
         await new Promise((resolve, reject) => {
@@ -381,8 +381,8 @@ class KafkaClient {
       if (this.#isConsumerConnected) {
         this.#consumer.subscribe([topic]);
 
-        if (!this.#intervalId) {
-          this.#intervalId = setInterval(() => {
+        if (!this.#consumerPollInterval) {
+          this.#consumerPollInterval = setInterval(() => {
             this.#consumer.consume(10);
           }, 1000);
         }
@@ -403,8 +403,8 @@ class KafkaClient {
       console.error(
         `Error occurred in consuming message from topic ${topic}: ${error}`,
       );
-      clearInterval(this.#intervalId);
-      this.#intervalId = null;
+      clearInterval(this.#consumerPollInterval);
+      this.#consumerPollInterval = null;
       throw new Error(
         `Error occurred in consuming message from topic ${topic}: ${error}`,
       );
@@ -458,8 +458,8 @@ class KafkaClient {
           return new Promise((resolve, reject) => {
             this.#consumer.once('disconnected', () => {
               this.#isConsumerConnected = false;
-              clearInterval(this.#intervalId);
-              this.#intervalId = null;
+              clearInterval(this.#consumerPollInterval);
+              this.#consumerPollInterval = null;
               this.#consumer.removeAllListeners();
               console.log('Successfully disconnected Kafka consumer');
             });


### PR DESCRIPTION
Based on the findings of @sandhana14 in https://github.com/cinemataztic/big-evil-kafka/pull/12

I believe the best approach is to simply take the missing broker producer polling (for ACK messages) and implement that in the pattern of the library. As there is diverge in the PR from this, I created a different PR to implement just this condition.

I (1) rename the consumer poll intervals, and then (2) add a producer poll interval. That's it.

I have created an issue for us to implement delivery-reports and the best process flow around them in a later iteration: https://github.com/cinemataztic/big-evil-kafka/issues/13