### PR TITLE
Add a delayed process.kill upon failed consumer connection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cinemataztic/big-evil-kafka",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cinemataztic/big-evil-kafka",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "license": "ISC",
       "dependencies": {
         "@kafkajs/confluent-schema-registry": "^3.6.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cinemataztic/big-evil-kafka",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "A wrapper around node-rdkafka",
   "main": "src/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -260,12 +260,8 @@ class KafkaClient {
         console.log(`Successfully published data to topic: ${topic}`);
       }
     } catch (error) {
-      console.error(
-        `Error occurred in sending message to topic ${topic}: ${error}`,
-      );
-      throw new Error(
-        `Error occurred in sending message to topic ${topic}: ${error}`,
-      );
+      console.error(`publishToTopic ('${topic}') failed: ${error}`);
+      throw new Error(`publishToTopic ('${topic}') failed: ${error}`);
     }
   }
 
@@ -298,21 +294,15 @@ class KafkaClient {
 
             onMessage({ value: decodedValue });
           } catch (error) {
-            console.error(
-              `Error occurred consuming messages from ${topic}: ${error}`,
-            );
+            console.error(`Consume from topic '${topic}' failed: ${error}`);
           }
         });
       }
     } catch (error) {
-      console.error(
-        `Error occurred in consuming message from topic ${topic}: ${error}`,
-      );
+      console.error(`subscribeToTopic ('${topic}') failed: ${error}`);
       clearInterval(this.#intervalId);
       this.#intervalId = null;
-      throw new Error(
-        `Error occurred in consuming message from topic ${topic}: ${error}`,
-      );
+      throw new Error(`subscribeToTopic ('${topic}') failed: ${error}`);
     }
   }
 
@@ -336,8 +326,8 @@ class KafkaClient {
         });
       }
     } catch (error) {
-      console.error(`Error disconnecting Producer: ${error}`);
-      throw new Error(`Error disconnecting Producer: ${error}`);
+      console.error(`Producer disconnect failed: ${error}`);
+      throw new Error(`Producer disconnect failed: ${error}`);
     }
   }
 
@@ -364,8 +354,8 @@ class KafkaClient {
     } catch (error) {
       clearInterval(this.#intervalId);
       this.#intervalId = null;
-      console.error(`Error disconnecting Consumer: ${error}`);
-      throw new Error(`Error disconnecting Consumer: ${error}`);
+      console.error(`Consumer disconnect failed: ${error}`);
+      throw new Error(`Consumer disconnect failed: ${error}`);
     }
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -206,7 +206,7 @@ class KafkaClient {
       }
     } catch (error) {
       console.error(`Error initializing producer: ${error.message}`);
-      throw new Error(`Error initializing producer: ${error.message}`)
+      throw new Error(`Error initializing producer: ${error.message}`);
     }
   }
 
@@ -222,7 +222,13 @@ class KafkaClient {
       }
     } catch (error) {
       console.error(`Error initializing consumer: ${error.message}`);
-      process.exit(1);
+      setTimeout(() => {
+        console.error(
+          'Application will be terminated in 10 seconds because the consumer failed to initialize.',
+        );
+        process.exit(1);
+      }, 10000);
+      throw error;
     }
   }
 


### PR DESCRIPTION
- Return an error message from `subscribeToTopic` before killing the client application.
- The client application shall be killed after 10 seconds once the consumer fails to initialize after multiple retry attempts.