### PR TITLE
Send `event.error` errors for consumers/producers from big-evil-kafka and separate try/catch block for initialization and functionality.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cinemataztic/big-evil-kafka",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cinemataztic/big-evil-kafka",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "license": "ISC",
       "dependencies": {
         "@kafkajs/confluent-schema-registry": "^3.6.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cinemataztic/big-evil-kafka",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cinemataztic/big-evil-kafka",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "ISC",
       "dependencies": {
         "@kafkajs/confluent-schema-registry": "^3.6.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cinemataztic/big-evil-kafka",
-  "version": "1.3.2",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cinemataztic/big-evil-kafka",
-      "version": "1.3.2",
+      "version": "1.4.0",
       "license": "ISC",
       "dependencies": {
         "@kafkajs/confluent-schema-registry": "^3.6.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cinemataztic/big-evil-kafka",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "A wrapper around node-rdkafka",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cinemataztic/big-evil-kafka",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "A wrapper around node-rdkafka",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cinemataztic/big-evil-kafka",
-  "version": "1.3.2",
+  "version": "1.4.0",
   "description": "A wrapper around node-rdkafka",
   "main": "src/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -376,7 +376,7 @@ class KafkaClient extends EventEmitter{
       const errorMessage = `Producer runtime error: ${error}`;
       console.error(errorMessage);
 
-      if (now - lastErrorEmit >= 1000) {
+      if (now - lastErrorEmit >= 60000) {
         lastErrorEmit = now;
         this.emit('producer.event.error', new Error(errorMessage), { source: 'producer' });
       }
@@ -390,7 +390,7 @@ class KafkaClient extends EventEmitter{
       const errorMessage = `Consumer runtime error: ${error}`;
       console.error(errorMessage);
 
-      if (now - lastErrorEmit >= 1000) {
+      if (now - lastErrorEmit >= 60000) {
         lastErrorEmit = now;
         this.emit('consumer.event.error', new Error(errorMessage), { source: 'consumer' });
       }

--- a/src/index.js
+++ b/src/index.js
@@ -152,7 +152,7 @@ class KafkaClient {
         this.#producerMaxRetries,
       );
     } catch (error) {
-      throw new Error(error);
+      throw new Error(error.message);
     }
   }
 
@@ -190,7 +190,7 @@ class KafkaClient {
         this.#consumerMaxRetries,
       );
     } catch (error) {
-      throw new Error(error);
+      throw new Error(error.message);
     }
   }
 


### PR DESCRIPTION
- Separate try/catch blocks for initialization and functionality, consuming/sending messages. 
- The error messages caught by clients won't mix the errors thrown by initialization with functionality in case initialization fail happen in a lazy initialization approach.
- Add [event emitter](https://nodejs.org/en/learn/asynchronous-work/the-nodejs-event-emitter) to emit custom `event.error` errors to the clients.