### PR TITLE
fix(api): ensure that subscribing to new topic does not overwrites the previous subscription.

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -15,14 +15,14 @@ jobs:
     runs-on: ubuntu-latest
     services:
       zookeeper:
-        image: confluentinc/cp-zookeeper:latest
+        image: confluentinc/cp-zookeeper:7.4.0
         ports:
           - 2181:2181
         env:
           ZOOKEEPER_CLIENT_PORT: 2181
 
       kafka:
-        image: confluentinc/cp-kafka:latest
+        image: confluentinc/cp-kafka:7.4.0
         ports:
           - 29092:29092
           - 9092:9092
@@ -42,7 +42,7 @@ jobs:
         options: --health-cmd="kafka-topics --bootstrap-server localhost:9092 --list || exit 1" --health-interval=10s --health-timeout=5s --health-retries=5    
 
       schema-registry:
-        image: confluentinc/cp-schema-registry:latest
+        image: confluentinc/cp-schema-registry:7.4.0
         ports:
           - 8081:8081
         env:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -60,14 +60,23 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Deploy 'cinemataztic-value' avro schema to schema-registry service
+      - name: Deploy avro schemas to schema-registry service
         run: |
+          # 1. Deploy 'cinemataztic-value' schema
           echo '{
             "schema": "{\"type\":\"record\",\"name\":\"HelloCinemataztic\",\"fields\":[{\"name\":\"message\",\"type\":\"string\"}]}"
-          }' > schema.json
+          }' > schema_default.json
 
           echo "Deploying 'cinemataztic-value' avro schema to schema-registry"
-          curl -X POST -H "Content-Type: application/vnd.schemaregistry.v1+json" --data @schema.json http://localhost:8081/subjects/cinemataztic-value/versions
+          curl -X POST -H "Content-Type: application/vnd.schemaregistry.v1+json" --data @schema_default.json http://localhost:8081/subjects/cinemataztic-value/versions
+
+          # 2. Deploy 'cinemataztic-a-value' schema
+          echo '{
+            "schema": "{\"type\":\"record\",\"name\":\"HelloCinematazticA\",\"fields\":[{\"name\":\"message\",\"type\":\"string\"}]}"
+          }' > schema_a.json
+
+          echo "\nDeploying 'cinemataztic-a-value' avro schema to schema-registry"
+          curl -X POST -H "Content-Type: application/vnd.schemaregistry.v1+json" --data @schema_a.json http://localhost:8081/subjects/cinemataztic-a-value/versions
 
       - name: Run tests
         run: npm run test:ci --if-present

--- a/.github/workflows/npm-publish.yaml
+++ b/.github/workflows/npm-publish.yaml
@@ -14,10 +14,10 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@master
         with:
-          node-version: '20.x'
+          node-version: '22'
           registry-url: https://registry.npmjs.org/
           scope: "@cinemataztic"
       - run: npm ci
-      - run: npm publish --access public 
+      - run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/npm-publish.yaml
+++ b/.github/workflows/npm-publish.yaml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@master
         with:
-          node-version: '22'
+          node-version: '24'
           registry-url: https://registry.npmjs.org/
           scope: "@cinemataztic"
       - run: npm ci

--- a/.github/workflows/npm-publish.yaml
+++ b/.github/workflows/npm-publish.yaml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
           registry-url: https://registry.npmjs.org/
           scope: "@cinemataztic"
       - run: npm ci

--- a/.github/workflows/npm-publish.yaml
+++ b/.github/workflows/npm-publish.yaml
@@ -7,6 +7,10 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   publish-npm:
     runs-on: ubuntu-latest

--- a/.github/workflows/npm-publish.yaml
+++ b/.github/workflows/npm-publish.yaml
@@ -15,10 +15,10 @@ jobs:
   publish-npm:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@master
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: '24'
+          node-version: '20'
           registry-url: https://registry.npmjs.org/
           scope: "@cinemataztic"
       - run: npm ci

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,3 @@
+__test__/
+.github/
+jest.config.js

--- a/README.md
+++ b/README.md
@@ -75,7 +75,10 @@ client.publishToTopic(topic, message);
 
 ## Subscribing to a Topic
 
-The package uses non-flowing consumer mode with `enable.auto.commit` enabled along with `auto.offset.reset` set to earliest.
+The package uses non-flowing consumer mode with `enable.auto.commit` disabled for manual commit internally along with `auto.offset.reset` set to earliest.
+```js
+this.#consumer.commitMessage(data);
+```
 
 The messages are consumed at an interval of 1 second with 10 messages consumed at each interval. 
 

--- a/__test__/index.test.js
+++ b/__test__/index.test.js
@@ -59,50 +59,54 @@ describe("Kafka client integration tests", () => {
     await messageReceivedPromise;
   });
 
-  test("should route messages from multiple topics to their respective callbacks", async () => {
-    const topicA = "cinemataztic";
-    const topicB = "cinemataztic-a";
-
+  test('should route messages from multiple topics to their respective callbacks', async () => {
+    const topicA = 'cinemataztic';
+    const topicB = 'cinemataztic-a';
+    
     const uniqueMessageA = `Message A - ${Date.now()}`;
     const uniqueMessageB = `Message B - ${Date.now()}`;
 
-    const messageReceivedPromiseA = new Promise((resolve, reject) => {
-      kafkaClient
-        .subscribeToTopic(topicA, (data) => {
-          try {
-            if (data?.value?.message === uniqueMessageA) {
-              expect(data).toHaveProperty("topic", topicA);
-              expect(data.value).toHaveProperty("message", uniqueMessageA);
-              resolve();
-            }
-          } catch (error) {
-            reject(error);
-          }
-        })
-        .catch(reject);
+    let resolveA, rejectA;
+    const messageReceivedPromiseA = new Promise((res, rej) => {
+      resolveA = res;
+      rejectA = rej;
     });
 
-    const messageReceivedPromiseB = new Promise((resolve, reject) => {
-      kafkaClient
-        .subscribeToTopic(topicB, (data) => {
-          try {
-            if (data?.value?.message === uniqueMessageB) {
-              expect(data).toHaveProperty("topic", topicB);
-              expect(data.value).toHaveProperty("message", uniqueMessageB);
-              resolve();
-            }
-          } catch (error) {
-            reject(error);
-          }
-        })
-        .catch(reject);
+    let resolveB, rejectB;
+    const messageReceivedPromiseB = new Promise((res, rej) => {
+      resolveB = res;
+      rejectB = rej;
     });
 
-    await new Promise((resolve) => setTimeout(resolve, 2000));
+    await kafkaClient.subscribeToTopic(topicA, (data) => {
+      try {
+        if (data?.value?.message === uniqueMessageA) {
+          expect(data).toHaveProperty('topic', topicA);
+          expect(data.value).toHaveProperty('message', uniqueMessageA);
+          resolveA(); // Trigger the promise to resolve
+        }
+      } catch (error) {
+        rejectA(error);
+      }
+    });
+
+    await kafkaClient.subscribeToTopic(topicB, (data) => {
+      try {
+        if (data?.value?.message === uniqueMessageB) {
+          expect(data).toHaveProperty('topic', topicB);
+          expect(data.value).toHaveProperty('message', uniqueMessageB);
+          resolveB(); // Trigger the promise to resolve
+        }
+      } catch (error) {
+        rejectB(error);
+      }
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 5000));
 
     await kafkaClient.publishToTopic(topicA, { message: uniqueMessageA });
     await kafkaClient.publishToTopic(topicB, { message: uniqueMessageB });
-
+ 
     await Promise.all([messageReceivedPromiseA, messageReceivedPromiseB]);
   });
 });

--- a/__test__/index.test.js
+++ b/__test__/index.test.js
@@ -10,7 +10,7 @@ jest.setTimeout(30000);
 beforeAll(async () => {
   kafkaClient = new KafkaClient({
     clientId: "ctz-client",
-    groupId: 'ctz-group',
+    groupId: "ctz-group",
     brokers: process.env.KAFKA_BROKERS
       ? process.env.KAFKA_BROKERS.split(",")
       : ["localhost:9092"],
@@ -43,13 +43,13 @@ describe("Kafka client integration tests", () => {
             if (data?.value?.message === uniqueMessage) {
               expect(data).toHaveProperty("value");
               expect(data.value).toHaveProperty("message", uniqueMessage);
-              resolve(); 
+              resolve();
             }
           } catch (error) {
-            reject(error); 
+            reject(error);
           }
         })
-        .catch(reject); 
+        .catch(reject);
     });
 
     await new Promise((resolve) => setTimeout(resolve, 2000));
@@ -59,10 +59,10 @@ describe("Kafka client integration tests", () => {
     await messageReceivedPromise;
   });
 
-  test('should route messages from multiple topics to their respective callbacks', async () => {
-    const topicA = 'cinemataztic';
-    const topicB = 'cinemataztic-a';
-    
+  test("should route messages from multiple topics to their respective callbacks", async () => {
+    const topicA = "cinemataztic";
+    const topicB = "cinemataztic-a";
+
     const uniqueMessageA = `Message A - ${Date.now()}`;
     const uniqueMessageB = `Message B - ${Date.now()}`;
 
@@ -81,8 +81,8 @@ describe("Kafka client integration tests", () => {
     await kafkaClient.subscribeToTopic(topicA, (data) => {
       try {
         if (data?.value?.message === uniqueMessageA) {
-          expect(data).toHaveProperty('topic', topicA);
-          expect(data.value).toHaveProperty('message', uniqueMessageA);
+          expect(data).toHaveProperty("topic", topicA);
+          expect(data.value).toHaveProperty("message", uniqueMessageA);
           resolveA(); // Trigger the promise to resolve
         }
       } catch (error) {
@@ -93,8 +93,8 @@ describe("Kafka client integration tests", () => {
     await kafkaClient.subscribeToTopic(topicB, (data) => {
       try {
         if (data?.value?.message === uniqueMessageB) {
-          expect(data).toHaveProperty('topic', topicB);
-          expect(data.value).toHaveProperty('message', uniqueMessageB);
+          expect(data).toHaveProperty("topic", topicB);
+          expect(data.value).toHaveProperty("message", uniqueMessageB);
           resolveB(); // Trigger the promise to resolve
         }
       } catch (error) {
@@ -106,7 +106,7 @@ describe("Kafka client integration tests", () => {
 
     await kafkaClient.publishToTopic(topicA, { message: uniqueMessageA });
     await kafkaClient.publishToTopic(topicB, { message: uniqueMessageB });
- 
+
     await Promise.all([messageReceivedPromiseA, messageReceivedPromiseB]);
   });
 });

--- a/__test__/index.test.js
+++ b/__test__/index.test.js
@@ -63,6 +63,10 @@ describe("Kafka client integration tests", () => {
     const topicA = "cinemataztic";
     const topicB = "cinemataztic-a";
 
+    await kafkaClient.publishToTopic(topicB, { message: "second-topic" });
+    
+    await new Promise((resolve) => setTimeout(resolve, 3000));
+
     const uniqueMessageA = `Message A - ${Date.now()}`;
     const uniqueMessageB = `Message B - ${Date.now()}`;
 
@@ -83,7 +87,7 @@ describe("Kafka client integration tests", () => {
         if (data?.value?.message === uniqueMessageA) {
           expect(data).toHaveProperty("topic", topicA);
           expect(data.value).toHaveProperty("message", uniqueMessageA);
-          resolveA(); // Trigger the promise to resolve
+          resolveA(); 
         }
       } catch (error) {
         rejectA(error);
@@ -95,7 +99,7 @@ describe("Kafka client integration tests", () => {
         if (data?.value?.message === uniqueMessageB) {
           expect(data).toHaveProperty("topic", topicB);
           expect(data.value).toHaveProperty("message", uniqueMessageB);
-          resolveB(); // Trigger the promise to resolve
+          resolveB(); 
         }
       } catch (error) {
         rejectB(error);

--- a/__test__/index.test.js
+++ b/__test__/index.test.js
@@ -60,8 +60,8 @@ describe("Kafka client integration tests", () => {
   });
 
   test("should route messages from multiple topics to their respective callbacks", async () => {
-    const topicA = "cinemataztic-a";
-    const topicB = "cinemataztic-b";
+    const topicA = "cinemataztic";
+    const topicB = "cinemataztic-a";
 
     const uniqueMessageA = `Message A - ${Date.now()}`;
     const uniqueMessageB = `Message B - ${Date.now()}`;

--- a/__test__/index.test.js
+++ b/__test__/index.test.js
@@ -1,58 +1,109 @@
-const { KafkaClient } = require('../src');
+const { KafkaClient } = require("../src");
 
-const topic = 'cinemataztic';
+const topic = "cinemataztic";
 
 let kafkaClient;
 let logSpy;
 
+jest.setTimeout(30000);
+
 beforeAll(async () => {
   kafkaClient = new KafkaClient({
-    clientId: 'ctz-client',
+    clientId: "ctz-client",
     groupId: 'ctz-group',
     brokers: process.env.KAFKA_BROKERS
-      ? process.env.KAFKA_BROKERS.split(',')
-      : ['localhost:9092'],
+      ? process.env.KAFKA_BROKERS.split(",")
+      : ["localhost:9092"],
   });
-  logSpy = jest.spyOn(console, 'log').mockImplementation();
+  logSpy = jest.spyOn(console, "log").mockImplementation();
 });
 
-describe('Kafka client integration tests', () => {
+describe("Kafka client integration tests", () => {
   beforeEach(async () => {
     jest.clearAllMocks();
   });
 
-  test('should log message when producer is connected', async () => {
-    await kafkaClient.publishToTopic(topic, { message: 'Hello Cinemataztic' });
-    expect(logSpy).toHaveBeenCalledWith(
-      'Producer connected',
-    );
+  test("should log message when producer is connected", async () => {
+    await kafkaClient.publishToTopic(topic, { message: "Hello Producer" });
+    expect(logSpy).toHaveBeenCalledWith("Producer connected");
   });
 
-  test('should log message when consumer is connected', async () => {
+  test("should log message when consumer is connected", async () => {
     await kafkaClient.subscribeToTopic(topic, () => {});
-    expect(logSpy).toHaveBeenCalledWith(
-      'Consumer connected',
-    );
+    expect(logSpy).toHaveBeenCalledWith("Consumer connected");
   });
 
-  test('should log message when consumer receives a message', async () => {
-    await kafkaClient.subscribeToTopic(topic, (data) => {
-      expect(data).toHaveProperty('value');
-      expect(data.value).toHaveProperty('message', 'Hello Cinemataztic');
+  test("should log message when consumer receives a message", async () => {
+    const uniqueMessage = `Hello Cinemataztic - ${Date.now()}`;
+
+    const messageReceivedPromise = new Promise((resolve, reject) => {
+      kafkaClient
+        .subscribeToTopic(topic, (data) => {
+          try {
+            if (data?.value?.message === uniqueMessage) {
+              expect(data).toHaveProperty("value");
+              expect(data.value).toHaveProperty("message", uniqueMessage);
+              resolve(); 
+            }
+          } catch (error) {
+            reject(error); 
+          }
+        })
+        .catch(reject); 
     });
 
-    // Wait for consumer to connect and subscribe.
     await new Promise((resolve) => setTimeout(resolve, 2000));
 
-    // Send a message after consumer is ready.
-    await kafkaClient.publishToTopic(topic, { message: 'Hello Cinemataztic' });
+    await kafkaClient.publishToTopic(topic, { message: uniqueMessage });
 
-    // Wait for the polling (via setInterval) to pick up the message.
-    await new Promise((resolve) => setTimeout(resolve, 5000));
+    await messageReceivedPromise;
   });
 
-  afterEach(() => {
-    jest.useRealTimers();
+  test("should route messages from multiple topics to their respective callbacks", async () => {
+    const topicA = "cinemataztic-a";
+    const topicB = "cinemataztic-b";
+
+    const uniqueMessageA = `Message A - ${Date.now()}`;
+    const uniqueMessageB = `Message B - ${Date.now()}`;
+
+    const messageReceivedPromiseA = new Promise((resolve, reject) => {
+      kafkaClient
+        .subscribeToTopic(topicA, (data) => {
+          try {
+            if (data?.value?.message === uniqueMessageA) {
+              expect(data).toHaveProperty("topic", topicA);
+              expect(data.value).toHaveProperty("message", uniqueMessageA);
+              resolve();
+            }
+          } catch (error) {
+            reject(error);
+          }
+        })
+        .catch(reject);
+    });
+
+    const messageReceivedPromiseB = new Promise((resolve, reject) => {
+      kafkaClient
+        .subscribeToTopic(topicB, (data) => {
+          try {
+            if (data?.value?.message === uniqueMessageB) {
+              expect(data).toHaveProperty("topic", topicB);
+              expect(data.value).toHaveProperty("message", uniqueMessageB);
+              resolve();
+            }
+          } catch (error) {
+            reject(error);
+          }
+        })
+        .catch(reject);
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+
+    await kafkaClient.publishToTopic(topicA, { message: uniqueMessageA });
+    await kafkaClient.publishToTopic(topicB, { message: uniqueMessageB });
+
+    await Promise.all([messageReceivedPromiseA, messageReceivedPromiseB]);
   });
 });
 

--- a/__test__/index.test.js
+++ b/__test__/index.test.js
@@ -10,7 +10,7 @@ jest.setTimeout(30000);
 beforeAll(async () => {
   kafkaClient = new KafkaClient({
     clientId: "ctz-client",
-    groupId: "ctz-group",
+    groupId: `ctz-group-${Date.now()}`, // Ensure a unique group ID for each test run to avoid consumer group conflicts
     brokers: process.env.KAFKA_BROKERS
       ? process.env.KAFKA_BROKERS.split(",")
       : ["localhost:9092"],
@@ -60,10 +60,12 @@ describe("Kafka client integration tests", () => {
   });
 
   test("should route messages from multiple topics to their respective callbacks", async () => {
+    jest.setTimeout(30000); 
+
     const topicA = "cinemataztic";
     const topicB = "cinemataztic-a";
 
-    await kafkaClient.publishToTopic(topicB, { message: "second-topic" });
+    await kafkaClient.publishToTopic(topicB, { message: "warm-up-topic" });
     
     await new Promise((resolve) => setTimeout(resolve, 3000));
 
@@ -87,6 +89,7 @@ describe("Kafka client integration tests", () => {
         if (data?.value?.message === uniqueMessageA) {
           expect(data).toHaveProperty("topic", topicA);
           expect(data.value).toHaveProperty("message", uniqueMessageA);
+          console.log("✅ Callback A successfully received and verified message!");
           resolveA(); 
         }
       } catch (error) {
@@ -99,6 +102,7 @@ describe("Kafka client integration tests", () => {
         if (data?.value?.message === uniqueMessageB) {
           expect(data).toHaveProperty("topic", topicB);
           expect(data.value).toHaveProperty("message", uniqueMessageB);
+          console.log("✅ Callback B successfully received and verified message!");
           resolveB(); 
         }
       } catch (error) {
@@ -110,8 +114,17 @@ describe("Kafka client integration tests", () => {
 
     await kafkaClient.publishToTopic(topicA, { message: uniqueMessageA });
     await kafkaClient.publishToTopic(topicB, { message: uniqueMessageB });
+    
+    const timeoutPromise = new Promise((_, reject) => {
+      setTimeout(() => reject(new Error("CRITICAL TIMEOUT: Callbacks never fired after 15 seconds. Consumer is not receiving data.")), 15000);
+    });
 
-    await Promise.all([messageReceivedPromiseA, messageReceivedPromiseB]);
+    await Promise.race([
+      Promise.all([messageReceivedPromiseA, messageReceivedPromiseB]),
+      timeoutPromise
+    ]);
+    
+    console.log("🎉 Test completed successfully!");
   });
 });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cinemataztic/big-evil-kafka",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cinemataztic/big-evil-kafka",
-      "version": "1.4.1",
+      "version": "1.5.0",
       "license": "ISC",
       "dependencies": {
         "@kafkajs/confluent-schema-registry": "^3.6.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cinemataztic/big-evil-kafka",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cinemataztic/big-evil-kafka",
-      "version": "1.5.3",
+      "version": "1.5.4",
       "license": "ISC",
       "dependencies": {
         "@kafkajs/confluent-schema-registry": "^3.6.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cinemataztic/big-evil-kafka",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cinemataztic/big-evil-kafka",
-      "version": "1.5.2",
+      "version": "1.5.3",
       "license": "ISC",
       "dependencies": {
         "@kafkajs/confluent-schema-registry": "^3.6.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cinemataztic/big-evil-kafka",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cinemataztic/big-evil-kafka",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "license": "ISC",
       "dependencies": {
         "@kafkajs/confluent-schema-registry": "^3.6.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cinemataztic/big-evil-kafka",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cinemataztic/big-evil-kafka",
-      "version": "1.5.1",
+      "version": "1.5.2",
       "license": "ISC",
       "dependencies": {
         "@kafkajs/confluent-schema-registry": "^3.6.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cinemataztic/big-evil-kafka",
-  "version": "1.5.7",
+  "version": "1.5.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cinemataztic/big-evil-kafka",
-      "version": "1.5.7",
+      "version": "1.5.8",
       "license": "ISC",
       "dependencies": {
         "@kafkajs/confluent-schema-registry": "^3.6.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cinemataztic/big-evil-kafka",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cinemataztic/big-evil-kafka",
-      "version": "1.5.4",
+      "version": "1.5.5",
       "license": "ISC",
       "dependencies": {
         "@kafkajs/confluent-schema-registry": "^3.6.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cinemataztic/big-evil-kafka",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cinemataztic/big-evil-kafka",
-      "version": "1.5.5",
+      "version": "1.5.6",
       "license": "ISC",
       "dependencies": {
         "@kafkajs/confluent-schema-registry": "^3.6.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cinemataztic/big-evil-kafka",
-  "version": "1.5.6",
+  "version": "1.5.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cinemataztic/big-evil-kafka",
-      "version": "1.5.6",
+      "version": "1.5.7",
       "license": "ISC",
       "dependencies": {
         "@kafkajs/confluent-schema-registry": "^3.6.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@kafkajs/confluent-schema-registry": "^3.6.1",
         "exponential-backoff": "^3.1.2",
         "jsdoc": "^4.0.4",
-        "node-rdkafka": "^3.2.1"
+        "node-rdkafka": "^3.6.1"
       },
       "devDependencies": {
         "better-docs": "^2.7.3",
@@ -3973,9 +3973,9 @@
       "license": "MIT"
     },
     "node_modules/nan": {
-      "version": "2.22.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.22.0.tgz",
-      "integrity": "sha512-nbajikzWTMwsW+eSsNm3QwlOs7het9gGJU5dDZzRTQGk03vyBOauxgI4VakDzE0PtsGTmXPsXTbbjVhRwR5mpw==",
+      "version": "2.27.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.27.0.tgz",
+      "integrity": "sha512-hC+0LidcL3XE4rp1C4H54KujgXKzbfyTngZTwBByQxsOxCEKZT0MPQ4hOKUH2jU1OYstqdDH4onyHPDzcV0XdQ==",
       "license": "MIT"
     },
     "node_modules/natural-compare": {
@@ -4013,14 +4013,14 @@
       "license": "MIT"
     },
     "node_modules/node-rdkafka": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/node-rdkafka/-/node-rdkafka-3.3.0.tgz",
-      "integrity": "sha512-LbeWj2WlyXnl0IKJhBHrU9aPPJ9e+Cxgp14vx6a/L6c1/SdUjN0a6R9KSVh/zl/sfkGYBh2MTa0e2Ya7hZvEHg==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/node-rdkafka/-/node-rdkafka-3.6.1.tgz",
+      "integrity": "sha512-sfpTbrT35429cs0RE8Yb9avGX9BiRRvpV7aweQsghKTjtrVZP3jBrKOPItWXAqHb8doyh3SkuGuUVBLgig1SRg==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "bindings": "^1.3.1",
-        "nan": "^2.22.0"
+        "nan": "^2.24.0"
       },
       "engines": {
         "node": ">=16"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cinemataztic/big-evil-kafka",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "A wrapper around node-rdkafka",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cinemataztic/big-evil-kafka",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "description": "A wrapper around node-rdkafka",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cinemataztic/big-evil-kafka",
-  "version": "1.5.7",
+  "version": "1.5.8",
   "description": "A wrapper around node-rdkafka",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cinemataztic/big-evil-kafka",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "A wrapper around node-rdkafka",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@kafkajs/confluent-schema-registry": "^3.6.1",
     "exponential-backoff": "^3.1.2",
     "jsdoc": "^4.0.4",
-    "node-rdkafka": "^3.2.1"
+    "node-rdkafka": "^3.6.1"
   },
   "devDependencies": {
     "better-docs": "^2.7.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cinemataztic/big-evil-kafka",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "description": "A wrapper around node-rdkafka",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cinemataztic/big-evil-kafka",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "A wrapper around node-rdkafka",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cinemataztic/big-evil-kafka",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "description": "A wrapper around node-rdkafka",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cinemataztic/big-evil-kafka",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "description": "A wrapper around node-rdkafka",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cinemataztic/big-evil-kafka",
-  "version": "1.5.6",
+  "version": "1.5.7",
   "description": "A wrapper around node-rdkafka",
   "main": "src/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -124,6 +124,7 @@ class KafkaClient extends EventEmitter {
         "metadata.broker.list": this.#brokers.join(","),
         "enable.auto.commit": true,
         "auto.commit.interval.ms": 1000,
+        "topic.metadata.refresh.interval.ms": 5000,
       },
       {
         "auto.offset.reset": "earliest",

--- a/src/index.js
+++ b/src/index.js
@@ -316,9 +316,6 @@ class KafkaClient extends EventEmitter {
         if (!this.#isDataListenerAttached) {
           this.#consumer.on("data", async (data) => {
             try {
-              const decodedValue = await this.#registry.decode(data.value);
-
-              // Route the message to the correct callback based on the topic
               const targetCallback = this.#topicCallbacks.get(data.topic);
 
               if (!targetCallback) {
@@ -331,6 +328,7 @@ class KafkaClient extends EventEmitter {
               console.log(
                 `Message received by consumer on topic: ${data.topic}`,
               );
+
               targetCallback({ value: decodedValue, topic: data.topic });
             } catch (error) {
               console.error(

--- a/src/index.js
+++ b/src/index.js
@@ -1,14 +1,14 @@
-const { Producer, KafkaConsumer } = require('node-rdkafka');
-const { SchemaRegistry } = require('@kafkajs/confluent-schema-registry');
-const { EventEmitter } = require('events');
+const { Producer, KafkaConsumer } = require("node-rdkafka");
+const { SchemaRegistry } = require("@kafkajs/confluent-schema-registry");
+const { EventEmitter } = require("events");
 
-const retryConnection = require('./utils/retryConnection');
+const retryConnection = require("./utils/retryConnection");
 
 /**
  * Kafka client which is a wrapper library around node-rdkafka
  *
  */
-class KafkaClient extends EventEmitter{
+class KafkaClient extends EventEmitter {
   /**
    * The client identifier .
    * @type {String}
@@ -81,6 +81,19 @@ class KafkaClient extends EventEmitter{
    * @private
    */
   #intervalId;
+  /**
+   * Stores callbacks mapped by topic.
+   * @type {Map<string, Function>}
+   * @private
+   */
+  #topicCallbacks = new Map();
+
+  /**
+   * Flag to ensure the data listener is only attached once.
+   * @type {Boolean}
+   * @private
+   */
+  #isDataListenerAttached = false;
 
   /**
    * Initialize Kafka Client
@@ -94,26 +107,26 @@ class KafkaClient extends EventEmitter{
    */
   constructor(config = {}) {
     super();
-    this.#clientId = config.clientId || 'default-client';
-    this.#groupId = config.groupId || 'default-group-id';
-    this.#brokers = config.brokers || ['localhost:9092'];
+    this.#clientId = config.clientId || "default-client";
+    this.#groupId = config.groupId || "default-group-id";
+    this.#brokers = config.brokers || ["localhost:9092"];
     this.#avroSchemaRegistry =
-      config.avroSchemaRegistry || 'http://localhost:8081';
+      config.avroSchemaRegistry || "http://localhost:8081";
     this.#producer = new Producer({
-      'client.id': this.#clientId,
-      'metadata.broker.list': this.#brokers.join(','),
+      "client.id": this.#clientId,
+      "metadata.broker.list": this.#brokers.join(","),
       dr_cb: false,
     });
     this.#consumer = new KafkaConsumer(
       {
-        'group.id': this.#groupId,
-        'client.id': this.#clientId,
-        'metadata.broker.list': this.#brokers.join(','),
-        'enable.auto.commit': true,
-        'auto.commit.interval.ms': 1000,
+        "group.id": this.#groupId,
+        "client.id": this.#clientId,
+        "metadata.broker.list": this.#brokers.join(","),
+        "enable.auto.commit": true,
+        "auto.commit.interval.ms": 1000,
       },
       {
-        'auto.offset.reset': 'earliest',
+        "auto.offset.reset": "earliest",
       },
     );
     this.#registry = new SchemaRegistry({ host: this.#avroSchemaRegistry });
@@ -132,7 +145,7 @@ class KafkaClient extends EventEmitter{
               cleanup();
               this.#isProducerConnected = true;
               this.#producer.setPollInterval(100);
-              console.log('Producer connected');
+              console.log("Producer connected");
               this.#registerProducerEventHandler();
               resolve();
             };
@@ -143,14 +156,14 @@ class KafkaClient extends EventEmitter{
             };
 
             const cleanup = () => {
-              this.#producer.removeListener('ready', onReady);
+              this.#producer.removeListener("ready", onReady);
             };
 
-            this.#producer.once('ready', onReady);
+            this.#producer.once("ready", onReady);
             this.#producer.connect({}, onConnectError);
           });
         },
-        'producer-connection',
+        "producer-connection",
         this.#producerMaxRetries,
       );
     } catch (error) {
@@ -170,7 +183,7 @@ class KafkaClient extends EventEmitter{
             const onReady = () => {
               cleanup();
               this.#isConsumerConnected = true;
-              console.log('Consumer connected');
+              console.log("Consumer connected");
               this.#registerConsumerEventHandler();
               resolve();
             };
@@ -181,14 +194,14 @@ class KafkaClient extends EventEmitter{
             };
 
             const cleanup = () => {
-              this.#consumer.removeListener('ready', onReady);
+              this.#consumer.removeListener("ready", onReady);
             };
 
-            this.#consumer.once('ready', onReady);
+            this.#consumer.once("ready", onReady);
             this.#consumer.connect({}, onConnectError);
           });
         },
-        'consumer-connection',
+        "consumer-connection",
         this.#consumerMaxRetries,
       );
     } catch (error) {
@@ -203,7 +216,7 @@ class KafkaClient extends EventEmitter{
   async #initProducer() {
     try {
       if (!this.#isProducerConnected) {
-        console.log('Initializing Producer..');
+        console.log("Initializing Producer..");
         await this.#connectProducer();
       }
     } catch (error) {
@@ -219,17 +232,12 @@ class KafkaClient extends EventEmitter{
   async #initConsumer() {
     try {
       if (!this.#isConsumerConnected) {
-        console.log('Initializing Consumer..');
+        console.log("Initializing Consumer..");
         await this.#connectConsumer();
       }
     } catch (error) {
       console.error(`Error initializing consumer: ${error.message}`);
-      setTimeout(() => {
-        console.error(
-          'Application will be terminated in 10 seconds because the consumer failed to initialize.',
-        );
-        process.exit(1);
-      }, 10000);
+      this.emit('fatal.error', new Error('Consumer failed to initialize'));
       throw new Error(`Error initializing consumer: ${error.message}`);
     }
   }
@@ -250,7 +258,7 @@ class KafkaClient extends EventEmitter{
     try {
       if (this.#isProducerConnected) {
         const subject = `${topic}-value`;
-        const id = await this.#registry.getRegistryId(subject, 'latest');
+        const id = await this.#registry.getRegistryId(subject, "latest");
 
         console.log(`Using schema ${topic}-value@latest (id: ${id})`);
 
@@ -287,8 +295,12 @@ class KafkaClient extends EventEmitter{
 
     try {
       if (this.#isConsumerConnected) {
-        this.#consumer.subscribe([topic]);
-        console.log(`Subscribed to topic ${topic}`);
+        this.#topicCallbacks.set(topic, onMessage);
+
+        // Subscribe to all topics that have registered callbacks
+        const allTopics = Array.from(this.#topicCallbacks.keys());
+        this.#consumer.subscribe(allTopics);
+        console.log(`Subscribed to topics: ${allTopics.join(", ")}`);
 
         if (!this.#intervalId) {
           this.#intervalId = setInterval(() => {
@@ -296,17 +308,32 @@ class KafkaClient extends EventEmitter{
           }, 1000);
         }
 
-        this.#consumer.on('data', async (data) => {
-          try {
-            const decodedValue = await this.#registry.decode(data.value);
+        // Attach the data listener only once to avoid multiple listeners being registered on subsequent subscribeToTopic calls
+        if (!this.#isDataListenerAttached) {
+          this.#consumer.on("data", async (data) => {
+            try {
+              const decodedValue = await this.#registry.decode(data.value);
 
-            console.log(`Message received by consumer on topic: ${topic}`);
+              // Route the message to the correct callback based on the topic
+              const targetCallback = this.#topicCallbacks.get(data.topic);
 
-            onMessage({ value: decodedValue });
-          } catch (error) {
-            console.error(`Consume from topic '${topic}' failed: ${error}`);
-          }
-        });
+              if (targetCallback) {
+                console.log(
+                  `Message received by consumer on topic: ${data.topic}`,
+                );
+                targetCallback({ value: decodedValue, topic: data.topic });
+              } else {
+                console.warn(`No callback registered for topic: ${data.topic}`);
+              }
+            } catch (error) {
+              console.error(
+                `Consume from topic '${data.topic}' failed: ${error}`,
+              );
+            }
+          });
+
+          this.#isDataListenerAttached = true;
+        }
       }
     } catch (error) {
       console.error(`subscribeToTopic ('${topic}') failed: ${error}`);
@@ -324,11 +351,11 @@ class KafkaClient extends EventEmitter{
     try {
       if (this.#isProducerConnected) {
         return new Promise((resolve) => {
-          this.#producer.once('disconnected', () => {
+          this.#producer.once("disconnected", () => {
             this.#isProducerConnected = false;
             this.#producer.setPollInterval(0);
             this.#producer.removeAllListeners();
-            console.log('Disconnected Producer');
+            console.log("Disconnected Producer");
             resolve();
           });
 
@@ -349,12 +376,14 @@ class KafkaClient extends EventEmitter{
     try {
       if (this.#isConsumerConnected) {
         return new Promise((resolve) => {
-          this.#consumer.once('disconnected', () => {
+          this.#consumer.once("disconnected", () => {
             this.#isConsumerConnected = false;
+            this.#isDataListenerAttached = false; // Reset data listener flag
+            this.#topicCallbacks.clear(); // Clear all registered callbacks
             this.#consumer.removeAllListeners();
             clearInterval(this.#intervalId);
             this.#intervalId = null;
-            console.log('Disconnected Consumer');
+            console.log("Disconnected Consumer");
             resolve();
           });
 
@@ -371,28 +400,32 @@ class KafkaClient extends EventEmitter{
 
   #registerProducerEventHandler() {
     let lastErrorEmit = 0;
-    this.#producer.on('event.error', (error) => {
+    this.#producer.on("event.error", (error) => {
       const now = Date.now();
       const errorMessage = `Producer runtime error: ${error}`;
       console.error(errorMessage);
 
       if (now - lastErrorEmit >= 60000) {
         lastErrorEmit = now;
-        this.emit('producer.event.error', new Error(errorMessage), { source: 'producer' });
+        this.emit("producer.event.error", new Error(errorMessage), {
+          source: "producer",
+        });
       }
     });
   }
 
   #registerConsumerEventHandler() {
     let lastErrorEmit = 0;
-    this.#consumer.on('event.error', (error) => {
+    this.#consumer.on("event.error", (error) => {
       const now = Date.now();
       const errorMessage = `Consumer runtime error: ${error}`;
       console.error(errorMessage);
 
       if (now - lastErrorEmit >= 60000) {
         lastErrorEmit = now;
-        this.emit('consumer.event.error', new Error(errorMessage), { source: 'consumer' });
+        this.emit("consumer.event.error", new Error(errorMessage), {
+          source: "consumer",
+        });
       }
     });
   }

--- a/src/index.js
+++ b/src/index.js
@@ -237,7 +237,7 @@ class KafkaClient extends EventEmitter {
       }
     } catch (error) {
       console.error(`Error initializing consumer: ${error.message}`);
-      this.emit('fatal.error', new Error('Consumer failed to initialize'));
+      this.emit("fatal.error", new Error("Consumer failed to initialize"));
       throw new Error(`Error initializing consumer: ${error.message}`);
     }
   }
@@ -299,7 +299,11 @@ class KafkaClient extends EventEmitter {
 
         // Subscribe to all topics that have registered callbacks
         const allTopics = Array.from(this.#topicCallbacks.keys());
+        if (!allTopics.includes(topic)) {
+          allTopics.push(topic);
+        }
         this.#consumer.subscribe(allTopics);
+        this.#topicCallbacks.set(topic, onMessage);
         console.log(`Subscribed to topics: ${allTopics.join(", ")}`);
 
         if (!this.#intervalId) {
@@ -317,14 +321,17 @@ class KafkaClient extends EventEmitter {
               // Route the message to the correct callback based on the topic
               const targetCallback = this.#topicCallbacks.get(data.topic);
 
-              if (targetCallback) {
-                console.log(
-                  `Message received by consumer on topic: ${data.topic}`,
-                );
-                targetCallback({ value: decodedValue, topic: data.topic });
-              } else {
+              if (!targetCallback) {
                 console.warn(`No callback registered for topic: ${data.topic}`);
+                return;
               }
+
+              const decodedValue = await this.#registry.decode(data.value);
+
+              console.log(
+                `Message received by consumer on topic: ${data.topic}`,
+              );
+              targetCallback({ value: decodedValue, topic: data.topic });
             } catch (error) {
               console.error(
                 `Consume from topic '${data.topic}' failed: ${error}`,

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,16 @@ const retryConnection = require("./utils/retryConnection");
  *
  */
 class KafkaClient extends EventEmitter {
+  /** The producer connection promise to ensure only one connection attempt is made at a time
+   * @type {Promise}
+   * @private
+   */
+  #producerConnectionPromise = null;
+  /** The consumer connection promise to ensure only one connection attempt is made at a time
+   * @type {Promise}
+   * @private
+   */
+  #consumerConnectionPromise = null;
   /**
    * The client identifier .
    * @type {String}
@@ -89,6 +99,13 @@ class KafkaClient extends EventEmitter {
   #topicCallbacks = new Map();
 
   /**
+   * A cache to store schema IDs for topics to avoid redundant registry lookups. The key is the subject name (e.g., 'topic-value') and the value is the corresponding schema ID.
+   * @type {Map<string, number>}
+   * @private
+   */
+  #schemaIdCache = new Map();
+
+  /**
    * Flag to ensure the data listener is only attached once.
    * @type {Boolean}
    * @private
@@ -122,7 +139,7 @@ class KafkaClient extends EventEmitter {
         "group.id": this.#groupId,
         "client.id": this.#clientId,
         "metadata.broker.list": this.#brokers.join(","),
-        "enable.auto.commit": true,
+        "enable.auto.commit": false,
         "auto.commit.interval.ms": 1000,
         "topic.metadata.refresh.interval.ms": 5000,
       },
@@ -142,26 +159,18 @@ class KafkaClient extends EventEmitter {
       await retryConnection(
         () => {
           return new Promise((resolve, reject) => {
-            const onReady = () => {
-              cleanup();
+            // node-rdkafka's producer.connect does not emit an error event when connection fails, instead it calls the callback with the error. Hence we handle success and failure scenarios within the callback itself and resolve or reject the promise accordingly.
+            this.#producer.connect({}, (err, metadata) => {
+              if (err) {
+                return reject(err);
+              }
+
               this.#isProducerConnected = true;
               this.#producer.setPollInterval(100);
               console.log("Producer connected");
               this.#registerProducerEventHandler();
               resolve();
-            };
-
-            const onConnectError = (error) => {
-              cleanup();
-              reject(error);
-            };
-
-            const cleanup = () => {
-              this.#producer.removeListener("ready", onReady);
-            };
-
-            this.#producer.once("ready", onReady);
-            this.#producer.connect({}, onConnectError);
+            });
           });
         },
         "producer-connection",
@@ -173,7 +182,7 @@ class KafkaClient extends EventEmitter {
   }
 
   /**
-   * Connects to node-rdkakfa client's consumer using an exponential backoff retry mechanism
+   * Connects to node-rdkafka client's consumer using an exponential backoff retry mechanism
    * @private
    */
   async #connectConsumer() {
@@ -181,25 +190,17 @@ class KafkaClient extends EventEmitter {
       await retryConnection(
         () => {
           return new Promise((resolve, reject) => {
-            const onReady = () => {
-              cleanup();
+            // node-rdkafka's consumer.connect does not emit an error event when connection fails, instead it calls the callback with the error. Hence we handle success and failure scenarios within the callback itself and resolve or reject the promise accordingly.
+            this.#consumer.connect({}, (err, metadata) => {
+              if (err) {
+                return reject(err);
+              }
+
               this.#isConsumerConnected = true;
               console.log("Consumer connected");
               this.#registerConsumerEventHandler();
               resolve();
-            };
-
-            const onConnectError = (error) => {
-              cleanup();
-              reject(error);
-            };
-
-            const cleanup = () => {
-              this.#consumer.removeListener("ready", onReady);
-            };
-
-            this.#consumer.once("ready", onReady);
-            this.#consumer.connect({}, onConnectError);
+            });
           });
         },
         "consumer-connection",
@@ -215,14 +216,23 @@ class KafkaClient extends EventEmitter {
    * @private
    */
   async #initProducer() {
+    if (this.#isProducerConnected) return;
+
+    // If a connection attempt is already in progress, wait for it to complete instead of starting a new one
+    if (this.#producerConnectionPromise) {
+      await this.#producerConnectionPromise;
+      return;
+    }
+
     try {
-      if (!this.#isProducerConnected) {
-        console.log("Initializing Producer..");
-        await this.#connectProducer();
-      }
+      console.log("Initializing Producer..");
+      this.#producerConnectionPromise = this.#connectProducer();
+      await this.#producerConnectionPromise;
     } catch (error) {
       console.error(`Error initializing producer: ${error.message}`);
       throw new Error(`Error initializing producer: ${error.message}`);
+    } finally {
+      this.#producerConnectionPromise = null; // Clear lock when done
     }
   }
 
@@ -231,15 +241,25 @@ class KafkaClient extends EventEmitter {
    * @private
    */
   async #initConsumer() {
+    if (this.#isConsumerConnected) return;
+
+    // If a connection attempt is already in progress, wait for it to complete instead of starting a new one
+    if (this.#consumerConnectionPromise) {
+      await this.#consumerConnectionPromise;
+      return;
+    }
+
     try {
       if (!this.#isConsumerConnected) {
         console.log("Initializing Consumer..");
-        await this.#connectConsumer();
+        this.#consumerConnectionPromise = this.#connectConsumer();
+        await this.#consumerConnectionPromise;
       }
     } catch (error) {
       console.error(`Error initializing consumer: ${error.message}`);
-      this.emit("fatal.error", new Error("Consumer failed to initialize"));
       throw new Error(`Error initializing consumer: ${error.message}`);
+    } finally {
+      this.#consumerConnectionPromise = null; // Clear lock when done
     }
   }
 
@@ -259,7 +279,13 @@ class KafkaClient extends EventEmitter {
     try {
       if (this.#isProducerConnected) {
         const subject = `${topic}-value`;
-        const id = await this.#registry.getRegistryId(subject, "latest");
+        let id = this.#schemaIdCache.get(subject);
+
+        // If the schema ID for the subject is not cached, fetch it from the registry and cache it for future use
+        if (!id) {
+          id = await this.#registry.getRegistryId(subject, "latest");
+          this.#schemaIdCache.set(subject, id);
+        }
 
         console.log(`Using schema ${topic}-value@latest (id: ${id})`);
 
@@ -296,45 +322,58 @@ class KafkaClient extends EventEmitter {
 
     try {
       if (this.#isConsumerConnected) {
-        this.#topicCallbacks.set(topic, onMessage);
-
-        // Subscribe to all topics that have registered callbacks
+        // 1. Maintain a local list of all topics we want to subscribe to, including the new one. This ensures we don't lose existing subscriptions when we call subscribe again, since node-rdkafka's subscribe replaces the entire subscription list instead of adding to it.
         const allTopics = Array.from(this.#topicCallbacks.keys());
         if (!allTopics.includes(topic)) {
           allTopics.push(topic);
         }
+
+        // 2. Call subscribe with the full list of topics we want to be subscribed to. This way we ensure that all our desired topics are registered with Kafka, and we don't accidentally drop any existing subscriptions.
         this.#consumer.subscribe(allTopics);
+
+        // 3. Store the callback for this topic in our local map so we can reference it when messages arrive. This allows us to have a single data listener that can route messages to the correct callback based on the topic, and also ensures that if we receive a message for a topic that we haven't fully registered yet (e.g., due to async timing), we can safely ignore it without crashing.
         this.#topicCallbacks.set(topic, onMessage);
+
         console.log(`Subscribed to topics: ${allTopics.join(", ")}`);
 
+        // 4. Start the consumer loop if it's not already running. We only want one loop running regardless of how many topics we subscribe to, so we check if the interval is already set before starting it. This ensures that we don't end up with multiple loops consuming messages concurrently, which could lead to duplicate processing
         if (!this.#intervalId) {
           this.#intervalId = setInterval(() => {
             this.#consumer.consume(10);
           }, 1000);
         }
 
-        // Attach the data listener only once to avoid multiple listeners being registered on subsequent subscribeToTopic calls
+        // 5. Attach a single data listener to the consumer if we haven't already. This listener will be responsible for routing incoming messages to the correct callback based on the topic. By checking the #isDataListenerAttached flag, we ensure that we only attach this listener once, even if subscribeToTopic is called multiple times. This prevents us from having multiple listeners attached to the 'data' event, which could cause messages to be processed multiple times or lead to memory leaks.
         if (!this.#isDataListenerAttached) {
           this.#consumer.on("data", async (data) => {
+            // When a message arrives, we look up the callback for its topic in our local map. This allows us to handle messages for multiple topics with a single listener, and also provides a safeguard in case we receive a message for a topic that we haven't fully registered yet (e.g., due to async timing). If we don't find a callback for the message's topic, we log a warning and ignore the message, allowing it to be processed by whoever owns it without crashing our consumer loop.
+            const targetCallback = this.#topicCallbacks.get(data.topic);
+
+            // Strategy A: If we receive a message for a topic that doesn't have a registered callback (e.g., due to async timing issues where the consumer receives a message before we've had a chance to store its callback in the map), we log a warning and skip processing that message. This allows the message to be processed by whoever owns it without crashing our consumer loop, and also provides visibility into potential timing issues in our subscription logic.
+            if (!targetCallback) {
+              console.warn(`No callback registered for topic: ${data.topic}`);
+              return;
+            }
+
             try {
-              const targetCallback = this.#topicCallbacks.get(data.topic);
-
-              if (!targetCallback) {
-                console.warn(`No callback registered for topic: ${data.topic}`);
-                return;
-              }
-
+              // Decode the message value using the schema registry. If decoding fails (e.g., due to a poison pill message that doesn't conform to the expected schema), we catch the error and log it, but we don't let it crash our consumer loop. This ensures that even if we encounter bad messages, our consumer can continue processing subsequent messages without getting stuck in a reboot loop.
               const decodedValue = await this.#registry.decode(data.value);
-
               console.log(
                 `Message received by consumer on topic: ${data.topic}`,
               );
 
-              targetCallback({ value: decodedValue, topic: data.topic });
+              // Call the registered callback for this topic with the decoded message. We wrap this in a try-catch block to handle any potential errors that might occur within the callback itself, ensuring that even if the callback crashes, it doesn't bring down our consumer loop. By logging the error stack trace, we can gain visibility into issues within our message processing logic without sacrificing the stability of our consumer.
+              await Promise.resolve(
+                targetCallback({ value: decodedValue, topic: data.topic }),
+              );
             } catch (error) {
+              // Strategy B: If we encounter an error while decoding a message (e.g., due to a poison pill message that doesn't conform to the expected schema), we catch the error and log it, but we don't let it crash our consumer loop. This ensures that even if we encounter bad messages, our consumer can continue processing subsequent messages without getting stuck in a reboot loop. By logging the error stack trace, we can gain visibility into issues with specific messages without sacrificing the stability of our consumer.
               console.error(
                 `Consume from topic '${data.topic}' failed: ${error}`,
               );
+            } finally {
+              // Regardless of whether processing succeeded or failed, we commit the message offset to ensure that we don't get stuck on a bad message. By committing the offset in the finally block, we guarantee that we won't repeatedly attempt to process the same poison pill message and get stuck in a reboot loop. This allows our consumer to continue making progress even in the face of bad messages, while still providing visibility into any issues through our error logging.
+              this.#consumer.commitMessage(data);
             }
           });
 
@@ -343,8 +382,11 @@ class KafkaClient extends EventEmitter {
       }
     } catch (error) {
       console.error(`subscribeToTopic ('${topic}') failed: ${error}`);
-      clearInterval(this.#intervalId);
-      this.#intervalId = null;
+      if (this.#topicCallbacks.size === 0 && this.#intervalId) {
+        clearInterval(this.#intervalId);
+        this.#intervalId = null;
+      }
+
       throw new Error(`subscribeToTopic ('${topic}') failed: ${error}`);
     }
   }
@@ -354,24 +396,28 @@ class KafkaClient extends EventEmitter {
    * @public
    */
   async disconnectProducer() {
-    try {
-      if (this.#isProducerConnected) {
-        return new Promise((resolve) => {
-          this.#producer.once("disconnected", () => {
-            this.#isProducerConnected = false;
-            this.#producer.setPollInterval(0);
-            this.#producer.removeAllListeners();
-            console.log("Disconnected Producer");
-            resolve();
-          });
+    if (!this.#isProducerConnected) return;
 
-          this.#producer.disconnect();
-        });
-      }
-    } catch (error) {
-      console.error(`Producer disconnect failed: ${error}`);
-      throw new Error(`Producer disconnect failed: ${error}`);
-    }
+    return new Promise((resolve, reject) => {
+      const timeoutId = setTimeout(() => {
+        console.warn(
+          "Producer disconnect timed out after 5000ms. Forcing shutdown.",
+        );
+        cleanup();
+      }, 5000);
+
+      const cleanup = () => {
+        clearTimeout(timeoutId);
+        this.#isProducerConnected = false;
+        this.#producer.setPollInterval(0);
+        this.#producer.removeAllListeners();
+        console.log("Disconnected Producer");
+        resolve();
+      };
+
+      this.#producer.once("disconnected", cleanup);
+      this.#producer.disconnect();
+    });
   }
 
   /**
@@ -379,29 +425,43 @@ class KafkaClient extends EventEmitter {
    * @public
    */
   async disconnectConsumer() {
-    try {
-      if (this.#isConsumerConnected) {
-        return new Promise((resolve) => {
-          this.#consumer.once("disconnected", () => {
-            this.#isConsumerConnected = false;
-            this.#isDataListenerAttached = false; // Reset data listener flag
-            this.#topicCallbacks.clear(); // Clear all registered callbacks
-            this.#consumer.removeAllListeners();
-            clearInterval(this.#intervalId);
-            this.#intervalId = null;
-            console.log("Disconnected Consumer");
-            resolve();
-          });
+    if (!this.#isConsumerConnected) return;
 
-          this.#consumer.disconnect();
-        });
+    return new Promise((resolve) => {
+      // Create a 5-second timeout fail-safe
+      const timeoutId = setTimeout(() => {
+        console.warn(
+          "Consumer disconnect timed out after 5000ms. Forcing shutdown.",
+        );
+        cleanup();
+      }, 5000);
+
+      const cleanup = () => {
+        clearTimeout(timeoutId);
+        this.#isConsumerConnected = false;
+        this.#isDataListenerAttached = false; // Reset data listener flag
+        this.#topicCallbacks.clear(); // Clear registered topic callbacks
+        this.#consumer.removeAllListeners();
+
+        if (this.#intervalId) {
+          clearInterval(this.#intervalId);
+          this.#intervalId = null;
+        }
+
+        console.log("Disconnected Consumer");
+        resolve();
+      };
+
+      this.#consumer.once("disconnected", cleanup);
+
+      try {
+        this.#consumer.disconnect();
+      } catch (error) {
+        // In case of an error during disconnect, log it and proceed with cleanup to avoid hanging
+        console.error(`Consumer disconnect threw an error: ${error.message}`);
+        cleanup();
       }
-    } catch (error) {
-      clearInterval(this.#intervalId);
-      this.#intervalId = null;
-      console.error(`Consumer disconnect failed: ${error}`);
-      throw new Error(`Consumer disconnect failed: ${error}`);
-    }
+    });
   }
 
   #registerProducerEventHandler() {


### PR DESCRIPTION
## 📝 Description
**What is the intent of this change?**
*Explain the "Why". If you are adding tooling, removing an app, or refactoring Kustomizations, clarify the expected outcome here.*

>- This PR addresses a bug in the library pertaining to subscribing different topics via consumer client. Earlier, consumer client supported only one subscription and upon a new topic and callback, the following line of code `this.#consumer. Subscribe([topic]) ` would overwrite the previous subscription and attaching a new `this.#consumer.on('data', ...)` listener would trigger both callbacks i.e one setup previously on each method call regardless of which topic the callback gets called for. The PR adds a Map for each topic|callback combination and ensures that the listener is attached only once to avoid multiple listeners being registered on subsequent `subscribeToTopic` calls.

>- Additionally this PR also changes the flow of Kafka Consumer by setting `auto.offset.reset` to false to allow manual offsets via `consumer.commitMessage`. 

**Changes made:**
* Fixed consumer subscription bug to ensure that it will support multiple topics and callbacks.
* Disabled `auto.offset.reset` to allow manual offsets of the messages.
* Optimized producer message by introducing a cache to ensure schema registry for same topic is not fetched over and over again.
* Add additional tests to verify the changes made to the consumer subscription mechanism.

**Expected Outcome:**
The library will support subscribing to multiple topics with their own callbacks. 

## ✅ First-Time Right Checklist
*To ensure this can be merged without a sync call, please verify:*

- [x] **Scope & Impact:** I have verified which environments are affected and what happens to the resources (e.g., new pods created, resources deleted, or shared base changes).
- [x] **Logical Consistency:** Configuration values (timeouts, intervals, naming) are consistent, and I've checked for potential race conditions in Flux syncs.
- [x] **Bot Warnings Addressed:** I have reviewed the Gemini/Bot comments. All "High" and "Medium" priority warnings are either resolved or explained.
- [x] **Relay Ready:** I have provided enough context/links for a reviewer in another timezone to understand the impact without asking me.

## 🤖 Bot / Technical Notes
*If you are ignoring any bot-suggested fixes or have specific technical remarks, please list them here:*
> NA.